### PR TITLE
Allow the user to use different binary of Chrome

### DIFF
--- a/src/main/java/io/webfolder/cdp/Launcher.java
+++ b/src/main/java/io/webfolder/cdp/Launcher.java
@@ -61,7 +61,7 @@ public class Launcher {
     }
 
     private String getChromeBinary() {
-        String chromeBinary = System.getProperty("chrome_binary");
+        String chromeBinary = getProperty("chrome_binary");
         if (chromeBinary != null) {
             File chromeExecutable = new File(chromeBinary);
             if (chromeExecutable.exists() && chromeExecutable.canExecute()) {

--- a/src/main/java/io/webfolder/cdp/Launcher.java
+++ b/src/main/java/io/webfolder/cdp/Launcher.java
@@ -51,13 +51,25 @@ public class Launcher {
     public Launcher() {
         this(new SessionFactory());
     }
-    
+
     public Launcher(int port) {
       this(new SessionFactory(port));
     }
 
     public Launcher(final SessionFactory factory) {
         this.factory = factory;
+    }
+
+    private String getChromeBinary() {
+        String chromeBinary = System.getProperty("chrome_binary");
+        if (chromeBinary != null) {
+            File chromeExecutable = new File(chromeBinary);
+            if (chromeExecutable.exists() && chromeExecutable.canExecute()) {
+                return chromeExecutable.getAbsolutePath();
+            }
+        }
+        // Return existing default binary
+        return "google-chrome";
     }
 
     public String findChrome() {
@@ -77,14 +89,14 @@ public class Launcher {
                         if (chrome.exists() && chrome.canExecute()) {
                             return chrome.toString();
                         }
-                    }                    
+                    }
                 }
                 throw new CdpException("Unable to find chrome.exe");
             } catch (Throwable e) {
                 // ignore
             }
         } else {
-            return "google-chrome";
+            return getChromeBinary();
         }
         return null;
     }
@@ -104,9 +116,9 @@ public class Launcher {
     public SessionFactory launch(List<String> arguments) {
         return launch(findChrome(), arguments);
     }
-    
+
     /**
-     * 
+     *
      * @deprecated As of release 1.1.0, replaced by {@link #launch(String, List)}
      */
     @Deprecated
@@ -143,7 +155,7 @@ public class Launcher {
         if ( ! arguments.isEmpty() ) {
             list.addAll(arguments);
         }
-        
+
         try {
             Process process = getRuntime().exec(list.toArray(new String[0]));
             process.getOutputStream().close();


### PR DESCRIPTION
- Allow `chrome_binary` property that user can set to different location
- Make it more flexible and work across different Linux/Mac OS system

### Background

#### Problem when running with installation of Google Chrome under Linux/Mac OS system

I got the following errors when running the following command

```sh
mvn clean test
```

```
io.webfolder.cdp.test.TestSession  Time elapsed: 0.725 sec  <<< ERROR!
java.lang.NullPointerException
	at io.webfolder.cdp.test.TestSession.dispose(TestSession.java:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)


Results :

Tests in error:
  io.webfolder.cdp.test.TestSession: java.io.IOException: Cannot run program "google-chrome": error=2, No such file or directory
  io.webfolder.cdp.test.TestSession

Tests run: 2, Failures: 0, Errors: 2, Skipped: 0
```

This PR will try to address this problem by allow the user to set the `chrome_binary` property that can point
to different location not necessary on the `PATH` e.g. when running the example provided

```sh
# Edit the path to your proper installation
mvn clean -Dchrome_binary=/usr/lib/chromium-dev/chromium-dev test
```

Which allow us to run the test successfully.

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running io.webfolder.cdp.test.TestSession
22:25:39.443 [main      ] INFO  navigate("file:/home/awesome/projects/staging/cdp4j/target/test-classes/session-test.html")
22:25:39.551 [main      ] INFO  activate()
22:25:39.642 [main      ] INFO  getTitle(): Session Test
22:25:39.661 [main      ] INFO  getAttribute("[type=text]", "value"): foo
22:25:39.670 [main      ] INFO  setAttribute("[type=text]", "value", "bar")
22:25:39.700 [main      ] INFO  getAttribute("[type=text]", "value"): bar
22:25:39.708 [main      ] INFO  setAttribute("[type=text]", "my-attr", "my-value")
22:25:39.727 [main      ] INFO  getAttribute("[type=text]", "my-attr"): my-value
22:25:39.741 [main      ] INFO  isChecked("#myradio"): true
22:25:39.741 [main      ] INFO  setChecked("#myradio", "false")
22:25:39.786 [main      ] INFO  isChecked("#myradio"): false
22:25:39.787 [main      ] INFO  click("#mybutton")
22:25:39.810 [main      ] INFO  focus("[type=text]")
22:25:39.819 [cpd4j-2   ] INFO  [console] [INFO] clicked
22:25:39.826 [cpd4j-2   ] INFO  [console] [INFO] focused
22:25:39.827 [main      ] INFO  selectInputText("[type=text]")
22:25:39.843 [main      ] INFO  sendBackspace()
22:25:39.858 [main      ] INFO  sendKeys("hello")
22:25:39.887 [main      ] INFO  getProperty("[type=text]", "value"): hello
22:25:39.887 [main      ] INFO  stop()
22:25:39.888 [main      ] INFO  reload()
22:25:39.919 [main      ] INFO  evaluate("2 + 2"): 4.0
22:25:39.929 [main      ] INFO  getSelectedIndex("#single-select"): -1
22:25:39.929 [main      ] INFO  setSelectedIndex("#single-select", "1")
22:25:39.953 [main      ] INFO  getSelectedIndex("#single-select"): 1
22:25:39.954 [main      ] INFO  clearOptions("#single-select")
22:25:39.978 [main      ] INFO  getSelectedIndex("#single-select"): -1
22:25:40.028 [main      ] INFO  setSelectOptions("#multi-select", "[1]")
22:25:40.174 [main      ] INFO  getProperty("p:contains('hello')", "innerHTML"): hello, world!
22:25:40.175 [main      ] INFO  setProperty("//p", "innerHTML", "hi")
22:25:40.185 [main      ] INFO  getProperty("p:contains('hi')", "innerHTML"): hi
22:25:40.186 [main      ] INFO  setDisabled("[type=text]", "true")
22:25:40.200 [main      ] INFO  isDisabled("[type=text]"): true
22:25:40.200 [main      ] INFO  focus("[type=text]")
22:25:40.212 [main      ] INFO  userAgent("my browser")
22:25:40.225 [main      ] INFO  evaluate("navigator.userAgent"): my browser
22:25:40.237 [main      ] INFO  callFunction("myfunc"): void
22:25:40.241 [main      ] INFO  evaluate("var foo = { }; foo.name = 'bar';"): bar
22:25:40.251 [cpd4j-3   ] INFO  [console] [INFO] [object Number]
22:25:40.261 [cpd4j-13  ] INFO  [console] [INFO] [object String]
22:25:40.270 [main      ] INFO  evaluate("window.myFunc2 = function(myMap) { return myMap; }"): null
22:25:40.276 [main      ] INFO  callFunction("myFunc2", {foo=bar}"): {foo=bar}
22:25:40.277 [main      ] INFO  close()
22:25:40.294 [cdp4j-terminate] INFO  close()
22:25:40.295 [cdp4j-terminate] INFO  close()
[    OK    ] navigate("file:/home/awesome/projects/staging/cdp4j/target/test-classes/session-test.html")
[    OK    ] activate()
[    OK    ] getTitle(): Session Test
[    OK    ] getAttribute("[type=text]", "value"): foo
[    OK    ] setAttribute("[type=text]", "value", "bar")
[    OK    ] getAttribute("[type=text]", "value"): bar
[    OK    ] setAttribute("[type=text]", "my-attr", "my-value")
[    OK    ] getAttribute("[type=text]", "my-attr"): my-value
[    OK    ] isChecked("#myradio"): true
[    OK    ] setChecked("#myradio", "false")
[    OK    ] isChecked("#myradio"): false
[    OK    ] click("#mybutton")
[    OK    ] focus("[type=text]")
[    OK    ] selectInputText("[type=text]")
[    OK    ] sendBackspace()
[    OK    ] sendKeys("hello")
[    OK    ] getProperty("[type=text]", "value"): hello
[    OK    ] stop()
[    OK    ] reload()
[    OK    ] evaluate("2 + 2"): 4.0
[    OK    ] getSelectedIndex("#single-select"): -1
[    OK    ] setSelectedIndex("#single-select", "1")
[    OK    ] getSelectedIndex("#single-select"): 1
[    OK    ] clearOptions("#single-select")
[    OK    ] getSelectedIndex("#single-select"): -1
[    OK    ] setSelectOptions("#multi-select", "[1]")
[    OK    ] getProperty("p:contains('hello')", "innerHTML"): hello, world!
[    OK    ] setProperty("//p", "innerHTML", "hi")
[    OK    ] getProperty("p:contains('hi')", "innerHTML"): hi
[    OK    ] setDisabled("[type=text]", "true")
[    OK    ] isDisabled("[type=text]"): true
[    OK    ] focus("[type=text]")
[    OK    ] userAgent("my browser")
[    OK    ] evaluate("navigator.userAgent"): my browser
[    OK    ] callFunction("myfunc"): void
[    OK    ] evaluate("var foo = { }; foo.name = 'bar';"): bar
[    OK    ] evaluate("window.myFunc2 = function(myMap) { return myMap; }"): null
[    OK    ] callFunction("myFunc2", {foo=bar}"): {foo=bar}
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.405 sec

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- jacoco-maven-plugin:0.7.9:report (jacoco-report) @ cdp4j ---
[INFO] Loading execution data file /home/awesome/projects/staging/cdp4j/target/jacoco.exec
[INFO] Analyzed bundle 'cdp4j' with 350 classes
[INFO]
[INFO] --- jacoco-maven-plugin:0.7.9:prepare-agent (jacoco-initialize) @ cdp4j ---
[INFO] argLine set to -javaagent:/home/awesome/.m2/repository/org/jacoco/org.jacoco.agent/0.7.9/org.jacoco.agent-0.7.9-runtime.jar=destfile=/home/awesome/projects/staging/cdp4j/target/jacoco.exec
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ cdp4j ---
[INFO] Using 'utf-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO]
[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ cdp4j ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ cdp4j ---
[INFO] Using 'utf-8' encoding to copy filtered resources.
[INFO] Copying 14 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ cdp4j ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cdp4j ---
[INFO] Skipping execution of surefire because it has already been run for this configuration
[INFO]
[INFO] --- jacoco-maven-plugin:0.7.9:report (jacoco-report) @ cdp4j ---
[INFO] Loading execution data file /home/awesome/projects/staging/cdp4j/target/jacoco.exec
[INFO] Analyzed bundle 'cdp4j' with 350 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 10.598 s
[INFO] Finished at: 2017-07-13T22:25:43-04:00
[INFO] Final Memory: 26M/263M
[INFO] ------------------------------------------------------------------------
