### PR TITLE
Don't check title for headless sessions

### DIFF
--- a/src/main/java/io/webfolder/cdp/session/SessionFactory.java
+++ b/src/main/java/io/webfolder/cdp/session/SessionFactory.java
@@ -453,8 +453,7 @@ public class SessionFactory implements AutoCloseable {
             return headlessSession;
         }
         for (SessionInfo next : sessionInfos) {
-            if ( "about:blank".equals(next.getTitle()) &&
-                        "about:blank".equals(next.getUrl()) &&
+            if ( "about:blank".equals(next.getUrl()) &&
                         next.getId() != null &&
                         ! next.getId().trim().isEmpty() &&
                         next.getWebSocketDebuggerUrl() != null &&


### PR DESCRIPTION
For Chrome on OSX, it is randomly set empty

Version 61.0.3160.0 (Official Build) canary (64-bit)
OSX version 10.11.6