### PR TITLE
Accessing frame child elements #36

### DIFF
--- a/src/main/java/io/webfolder/cdp/session/Dom.java
+++ b/src/main/java/io/webfolder/cdp/session/Dom.java
@@ -139,20 +139,39 @@ public interface Dom {
      * @return this
      */
     default Session focus(final String selector) {
-        return focus(selector, Constant.EMPTY_ARGS);
+		Integer nullValue = null;
+		return focus(nullValue, selector);
+	}
+
+	/**
+	 * The HTMLElement.focus() method sets focus on the specified element, if it
+	 * can be focused.
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param contextId
+	 *            Context id of the frame
+	 * @return this
+	 */
+	default Session focus(final Integer contextId, final String selector) {
+		return focus(contextId, selector, Constant.EMPTY_ARGS);
     }
 
     /**
-     * The HTMLElement.focus() method sets focus on the specified element, if it can be focused.
-     * 
-     * @param selector css or xpath selector
-     * @param args format string
-     * 
-     * @return this
-     */
-    default Session focus(final String selector, final Object ...args) {
+	 * The HTMLElement.focus() method sets focus on the specified element, if it
+	 * can be focused.
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param args
+	 *            format string
+	 * @param contextId
+	 *            Context id of the frame
+	 * @return this
+	 */
+	default Session focus(Integer contextId, final String selector, final Object... args) {
         getThis().logEntry("focus", format(selector, args));
-        Integer nodeId = getThis().getNodeId(selector, args);
+		Integer nodeId = getThis().getNodeId(contextId, selector, contextId, args);
         if (nodeId == null || Constant.EMPTY_NODE_ID.equals(nodeId)) {
             throw new ElementNotFoundException(format(selector, args));
         }
@@ -632,18 +651,36 @@ public interface Dom {
         return getAttributes(selector, Constant.EMPTY_ARGS);
     }
 
+	/**
+	 * Gets attributes of the node or {@link Collections#emptyMap()} otherwise.
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param args
+	 *            format string
+	 * 
+	 * @return returns all attribute nodes registered to the specified node.
+	 */
+	default Map<String, String> getAttributes(final String selector, final Object... args) {
+		return getAttributes(null, selector, args);
+	}
+
     /**
-     * Gets attributes of the node or {@link Collections#emptyMap()} otherwise.
-     * 
-     * @param selector css or xpath selector
-     * @param args format string
-     * 
-     * @return returns all attribute nodes registered to the specified node. 
-     */
+	 * Gets attributes of the node or {@link Collections#emptyMap()} otherwise.
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param args
+	 *            format string
+	 * @param contextId
+	 *            Frame context id
+	 * @return returns all attribute nodes registered to the specified node.
+	 */
     default Map<String, String> getAttributes(
+			Integer contextId,
                                 final String selector,
                                 final Object ...args) {
-        Integer nodeId = getThis().getNodeId(selector, args);
+		Integer nodeId = getThis().getNodeId(contextId, selector, args);
         if (nodeId != null && nodeId.intValue() > 0) {
             DOM dom = getThis().getCommand().getDOM();
             List<String> attributes = dom.getAttributes(nodeId);
@@ -683,13 +720,31 @@ public interface Dom {
      * @return the value of attribute or <code>null</code> if there is no such attribute.
      */
     default String getAttribute(
+			final String selector, final String name, final Object... args) {
+		return getAttribute(null, selector, name, args);
+	}
+
+	/**
+	 * Retrieves an attribute value by name.
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param name
+	 *            the name of the attribute to retrieve
+	 * @param args
+	 *            format string
+	 * 
+	 * @return the value of attribute or <code>null</code> if there is no such
+	 *         attribute.
+	 */
+	default String getAttribute(Integer contextId,
                         final String selector,
                         final String name,
                         final Object ...args) {
         if (name == null || name.trim().isEmpty()) {
             return null;
         }
-        String value = getAttributes(format(selector, args)).get(name);
+		String value = getAttributes(contextId, format(selector, args)).get(name);
         getThis().logExit("getAttribute", format(selector, args) + "\", \"" + name, value);
         return value;
     }
@@ -709,7 +764,26 @@ public interface Dom {
                         final String name,
                         final Object value,
                         final Object ...args) {
-        Integer nodeId = getThis().getNodeId(selector, args);
+		return setAttribute(null, selector, name, value, args);
+	}
+
+	/**
+	 * Sets attribute for an element
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param name
+	 *            the name of the attribute to create or alter
+	 * @param value
+	 *            value to set in string form
+	 * @param args
+	 *            format string
+	 * 
+	 * @return this
+	 */
+	default Session setAttribute(Integer contextId, final String selector, final String name, final Object value,
+			final Object... args) {
+		Integer nodeId = getThis().getNodeId(contextId, selector, args);
         if (nodeId == null || Constant.EMPTY_NODE_ID.equals(nodeId)) {
             throw new ElementNotFoundException(format(selector, args));
         }
@@ -736,7 +810,6 @@ public interface Dom {
                         final Object value) {
         return setAttribute(selector, name, value, Constant.EMPTY_ARGS);
     }
-
     /**
      * Gets box model of an element
      * 
@@ -748,7 +821,23 @@ public interface Dom {
      * @return Box model of element or <code>null</code> otherwise
      */
     default BoxModel getBoxModel(final String selector, Object ...args) {
-        Integer nodeId = getThis().getNodeId(selector, args);
+		return getBoxModel(null, selector, args);
+	}
+
+	/**
+	 * Gets box model of an element
+	 * 
+	 * Box model hold the height, width and coordinate of the element
+	 * 
+	 * @param selector
+	 *            css or xpath selector
+	 * @param args
+	 *            fromat string
+	 * 
+	 * @return Box model of element or <code>null</code> otherwise
+	 */
+	default BoxModel getBoxModel(Integer contextId, final String selector, Object... args) {
+		Integer nodeId = getThis().getNodeId(contextId, selector, args);
         if (nodeId == null || Constant.EMPTY_NODE_ID.equals(nodeId)) {
             throw new ElementNotFoundException(format(selector, args));
         }

--- a/src/test/java/io/webfolder/cdp/test/TestFrame.java
+++ b/src/test/java/io/webfolder/cdp/test/TestFrame.java
@@ -1,0 +1,145 @@
+package io.webfolder.cdp.test;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.webfolder.cdp.Launcher;
+import io.webfolder.cdp.event.Events;
+import io.webfolder.cdp.event.dom.SetChildNodes;
+import io.webfolder.cdp.event.runtime.ExecutionContextCreated;
+import io.webfolder.cdp.listener.EventListener;
+import io.webfolder.cdp.session.Session;
+import io.webfolder.cdp.session.SessionFactory;
+import io.webfolder.cdp.type.dom.Node;
+import io.webfolder.cdp.type.runtime.ExecutionContextDescription;
+
+public class TestFrame {
+	private static CdpAppender appender;
+
+	private static SessionFactory factory;
+
+	private static Session session;
+
+	private static LoggerContext loggerContext;
+
+	private static FrameEventListener eventListener;
+
+	@BeforeClass
+	@SuppressWarnings("unchecked")
+	public static void init() {
+		loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+		appender = new CdpAppender();
+		appender.setContext(loggerContext);
+		appender.start();
+		appender.setName(CdpAppender.class.getName());
+
+		Logger logger = loggerContext.getLogger("cdp4j.flow");
+		logger.addAppender((Appender<ILoggingEvent>) appender);
+
+		factory = new Launcher().launch();
+		eventListener = new FrameEventListener();
+
+		session = factory.create();
+		session.addEventListener(eventListener);
+		session.getCommand().getRuntime().enable();
+		session.enableConsoleLog();
+
+		URL url = TestSession.class.getResource("/frame-test.html");
+		session.navigate(url.toString());
+	}
+
+	@AfterClass
+	public static void dispose() {
+		appender.stop();
+		loggerContext.stop();
+		factory.close();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void test() {
+
+		// Needed so that xpaths work correctly.
+		session.getCommand().getDOM().getDocument();
+
+		String linkValue = session.getAttribute("//a[@id='link']", "href");
+		Assert.assertEquals("Not expected value", "https://www.google.com", linkValue);
+
+		String frameObjectId = session.getObjectId("//iframe");
+		final Integer frameNodeId = session.getCommand().getDOM().requestNode(frameObjectId);
+		final ExecutionContextDescription ecFrame = eventListener.getExecutionContextForFrame(frameNodeId);
+		linkValue = session.getAttribute(ecFrame.getId(), "//a[@id='link']", "href");
+		Assert.assertEquals("Not expected value", "https://www.yahoo.com", linkValue);
+	}
+
+	private static class FrameEventListener implements EventListener<Object> {
+
+		CopyOnWriteArrayList<Node> nodes;
+
+		CopyOnWriteArrayList<ExecutionContextDescription> executionContexts;
+
+		FrameEventListener() {
+			nodes = new CopyOnWriteArrayList<>();
+			executionContexts = new CopyOnWriteArrayList<>();
+		}
+
+		public Node findNodeById(final Integer nodeId) {
+
+			for (final Node node : nodes) {
+				if (Objects.equals(node.getNodeId(), nodeId)) {
+					return node;
+				}
+			}
+			return null;
+		}
+
+		public ExecutionContextDescription getExecutionContextForFrame(final Integer nodeId) {
+			final Node node = findNodeById(nodeId);
+			if (node != null) {
+				return getExecutionContextForFrame(node.getFrameId());
+			}
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		public ExecutionContextDescription getExecutionContextForFrame(final String frameId) {
+
+			Map<String, Object> map;
+			for (final ExecutionContextDescription ecd : executionContexts) {
+				map = (Map<String, Object>) ecd.getAuxData();
+				if (Objects.equals(map.get("frameId"), frameId)) {
+					return ecd;
+				}
+			}
+
+			return null;
+		}
+
+		@Override
+		public void onEvent(final Events event, final Object value) {
+			if (Events.DOMSetChildNodes == event) {
+				nodes.clear();
+				final SetChildNodes scn = (SetChildNodes) value;
+				nodes.addAll(scn.getNodes());
+			}
+			if (Events.RuntimeExecutionContextCreated == event) {
+				final ExecutionContextCreated exc = (ExecutionContextCreated) value;
+				executionContexts.add(exc.getContext());
+			}
+		}
+
+	}
+}

--- a/src/test/resources/frame-test.html
+++ b/src/test/resources/frame-test.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>iFrame Test</title>
+</head>
+<body>
+    <a href="https://www.google.com" target="_new" id="link">From top frame, google.com</a>
+    <br/>
+    <iframe src="iframe.html" style="width:100%;"></iframe>
+
+</body>
+</html>

--- a/src/test/resources/iframe.html
+++ b/src/test/resources/iframe.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <a href="https://www.yahoo.com" target="_new" id="link">In the frame, yahoo.com</a>
+    <br/>
+    <input name="userid" id="userid">
+  </body>
+</html>


### PR DESCRIPTION
Issue [36](https://github.com/webfolderio/cdp4j/issues/36)

Please excuse my lack of knowledge if I am doing something wrong. This is the first time I am creating github pull request.

Root of the change is in the (renamed) method  getObjectIdWithContext. We are passing contextId parameter to Runtime.evaluate function

I was forced to change the method name because of last optional parameter of the method -args. There was some confusion whether contextId is part of args or separate parameter. 

For consistency all methods I have modified accept contextId as a first parameter for reason mentioned above and to me it felt logical that you mention frame first before using selector.

Current changes will work with only xpath selectors. I'm still trying to figure out how to minimize the changes and get desired document for query selectors. Most probably will be done tomorrow