### PR TITLE
better treatment for the memory leak

### DIFF
--- a/src/main/java/io/webfolder/cdp/session/WSAdapter.java
+++ b/src/main/java/io/webfolder/cdp/session/WSAdapter.java
@@ -110,7 +110,7 @@ class WSAdapter extends WebSocketAdapter {
                 String id = idElement.getAsString();
                 if (id != null) {
                     int valId = (int) parseDouble(id);
-                    WSContext context = contextList.get(valId);
+                    WSContext context = contextList.remove(valId);
                     if (context != null) {
                         JsonObject error = object.getAsJsonObject("error");
                         if (error != null) {
@@ -120,10 +120,8 @@ class WSAdapter extends WebSocketAdapter {
                             context.setError(new CommandException(code, message +
                                                         (messageData != null && messageData.isJsonPrimitive() ? ". " +
                                                         messageData.getAsString() : "")));
-                            contextList.remove(valId);
                         } else {
                             context.setData(json);
-                            contextList.remove(valId);
                         }
                     }
                 }


### PR DESCRIPTION
I experimented with your library and experienced out-of-heap/gc errors.  I analyzed heap dumps and found out that you didn't remove records from the contextList map. By coincidence you fixed this just today (and btw this is not 'minor' leak, if you run the library for several hours, this will drain your heap). I would like to propose more concise and reliable fix.