### PR TITLE
RemoteLauncher implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,11 @@
    <scope>provided</scope>
   </dependency>
   <dependency>
+   <groupId>com.jcabi</groupId>
+   <artifactId>jcabi-ssh</artifactId>
+   <version>1.6</version>
+  </dependency>
+  <dependency>
    <groupId>ch.qos.logback</groupId>
    <artifactId>logback-classic</artifactId>
    <version>1.2.3</version>

--- a/src/main/java/io/webfolder/cdp/AbstractLauncher.java
+++ b/src/main/java/io/webfolder/cdp/AbstractLauncher.java
@@ -4,15 +4,11 @@ import io.webfolder.cdp.exception.CdpException;
 import io.webfolder.cdp.session.SessionFactory;
 import io.webfolder.cdp.session.SessionInfo;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.webfolder.cdp.session.SessionFactory.DEFAULT_HOST;
 import static java.lang.String.format;
-import static java.lang.System.getProperty;
 import static java.lang.Thread.sleep;
-import static java.nio.file.Paths.get;
 import static java.util.Collections.emptyList;
 
 abstract class AbstractLauncher {

--- a/src/main/java/io/webfolder/cdp/AbstractLauncher.java
+++ b/src/main/java/io/webfolder/cdp/AbstractLauncher.java
@@ -1,0 +1,116 @@
+package io.webfolder.cdp;
+
+import io.webfolder.cdp.exception.CdpException;
+import io.webfolder.cdp.session.SessionFactory;
+import io.webfolder.cdp.session.SessionInfo;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.webfolder.cdp.session.SessionFactory.DEFAULT_HOST;
+import static java.lang.String.format;
+import static java.lang.System.getProperty;
+import static java.lang.Thread.sleep;
+import static java.nio.file.Paths.get;
+import static java.util.Collections.emptyList;
+
+abstract class AbstractLauncher {
+    protected final SessionFactory factory;
+
+    public AbstractLauncher(final SessionFactory factory) {
+        this.factory = factory;
+    }
+
+    protected List<String> getCommonParameters(String chromeExecutablePath, List<String> arguments) {
+        List<String> list = new ArrayList<>();
+        list.add(chromeExecutablePath);
+        list.add(format("--remote-debugging-port=%d", factory.getPort()));
+
+        // Disable built-in Google Translate service
+        list.add("--disable-translate");
+        // Disable all chrome extensions entirely
+        list.add("--disable-extensions");
+        // Disable various background network services, including extension updating,
+        // safe browsing service, upgrade detector, translate, UMA
+        list.add("--disable-background-networking");
+        // Disable fetching safebrowsing lists, likely redundant due to disable-background-networking
+        list.add("--safebrowsing-disable-auto-update");
+        // Disable syncing to a Google account
+        list.add("--disable-sync");
+        // Disable reporting to UMA, but allows for collection
+        list.add("--metrics-recording-only");
+        // Disable installation of default apps on first run
+        list.add("--disable-default-apps");
+        // Mute any audio
+        list.add("--mute-audio");
+        // Skip first run wizards
+        list.add("--no-first-run");
+        list.add("--no-default-browser-check");
+        list.add("--disable-plugin-power-saver");
+        list.add("--disable-popup-blocking");
+
+        if (!arguments.isEmpty()) {
+            list.addAll(arguments);
+        }
+        return list;
+    }
+
+    public boolean launched() {
+        List<SessionInfo> list = emptyList();
+        try {
+            int timeout = 1000; // milliseconds
+            list = factory.list(timeout);
+        } catch (Throwable t) {
+            // ignore
+        }
+        return !list.isEmpty() ? true : false;
+    }
+
+    public abstract String findChrome();
+
+    public final SessionFactory launch() {
+        return launch(findChrome(), emptyList());
+    }
+
+    public final SessionFactory launch(List<String> arguments) {
+        return launch(findChrome(), arguments);
+    }
+
+    public final SessionFactory launch(String chromeExecutablePath, List<String> arguments){
+        if (launched()) {
+            return factory;
+        }
+
+        if (chromeExecutablePath == null || chromeExecutablePath.trim().isEmpty()) {
+            throw new CdpException("chrome not found");
+        }
+
+        List<String> list = getCommonParameters(chromeExecutablePath, arguments);
+
+        internalLaunch(list, arguments);
+
+        if (!launched()) {
+            int counter = 0;
+            final int maxCount = 20;
+            while (!launched() && counter < maxCount) {
+                try {
+                    sleep(500);
+                    counter += 1;
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        }
+
+        if (!launched()) {
+            throw new CdpException("Unable to connect to the chrome remote debugging server [" +
+                    factory.getHost() + ":" + factory.getPort() + "]");
+        }
+        return factory;
+    }
+
+    protected abstract void internalLaunch(List<String> list, List<String> params);
+
+    public abstract void kill();
+}

--- a/src/main/java/io/webfolder/cdp/AdaptiveProcessManager.java
+++ b/src/main/java/io/webfolder/cdp/AdaptiveProcessManager.java
@@ -36,9 +36,10 @@ public class AdaptiveProcessManager extends ProcessManager {
     private static final boolean JAVA_8  = getProperty("java.version").startsWith("1.8.");
 
     public AdaptiveProcessManager() {
-        if ( ! JAVA_8 ) {
-            processManager = new DefaultProcessManager();
-        } else if (WINDOWS) {
+        //if ( ! JAVA_8 ) {
+        //   processManager = new DefaultProcessManager();
+        //} else
+        if (WINDOWS) {
             processManager = new WindowsProcessManager();
         } else if (LINUX) {
             processManager = new LinuxProcessManager();

--- a/src/main/java/io/webfolder/cdp/RemoteLauncher.java
+++ b/src/main/java/io/webfolder/cdp/RemoteLauncher.java
@@ -1,0 +1,98 @@
+/**
+ * cdp4j - Chrome DevTools Protocol for Java
+ * Copyright © 2017 WebFolder OÜ (support@webfolder.io)
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.webfolder.cdp;
+
+import com.jcabi.ssh.Shell;
+import com.jcabi.ssh.Ssh;
+import com.jcabi.ssh.SshByPassword;
+import io.webfolder.cdp.exception.CdpException;
+import io.webfolder.cdp.session.SessionFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.joining;
+
+public class RemoteLauncher extends AbstractLauncher {
+    private final String host;
+    private final int sshPort;
+    private final String user;
+    private final String password;
+    private final String privateKey;
+    private final String chromeExecutable;
+
+    private Shell shell;
+    private int pid = -1;
+
+    RemoteLauncher(String host, int sshPort, int chromePort, String user, String password, String privateKey, String chromeExecutable) {
+        super(new SessionFactory(host, chromePort));
+        this.host = host;
+        this.sshPort = sshPort;
+        this.user = user;
+        this.password = password;
+        this.privateKey = privateKey;
+        this.chromeExecutable = chromeExecutable;
+    }
+
+    @Override
+    public String findChrome() {
+        return chromeExecutable;
+    }
+
+    @Override
+    protected void internalLaunch(List<String> list, List<String> parameters) {
+        if (parameters.stream().noneMatch(arg -> arg.startsWith("--remote-debugging-address="))) {
+            list.add("--remote-debugging-address=" + host);
+        }
+        String cmd = list.stream().collect(joining(" "));
+        try {
+            String result = new Shell.Plain(getShell()).exec(cmd + " > /dev/null 2> /dev/null < /dev/null &\necho ==$!==\n");
+            //extracting process id from preformatted shell output
+            Matcher m = Pattern.compile("==(\\d+)==").matcher(result);
+            m.find();
+            pid = Integer.parseInt(m.group(1));
+        } catch (IOException e) {
+            throw new CdpException(e);
+        }
+    }
+
+    @Override
+    public void kill() {
+        if (pid > 0) {
+            try {
+                new Shell.Empty(getShell()).exec("kill " + pid);
+            } catch (IOException e) {
+                throw new CdpException(e);
+            }
+        }
+    }
+
+    synchronized Shell getShell() throws IOException {
+        if (shell == null) {
+            shell = password.isEmpty()
+                    ?
+                    new Ssh(host, sshPort, user, privateKey)
+                    :
+                    new SshByPassword(host, sshPort, user, password);
+        }
+        return shell;
+    }
+}

--- a/src/main/java/io/webfolder/cdp/RemoteLauncher.java
+++ b/src/main/java/io/webfolder/cdp/RemoteLauncher.java
@@ -85,7 +85,7 @@ public class RemoteLauncher extends AbstractLauncher {
         }
     }
 
-    synchronized Shell getShell() throws IOException {
+    synchronized public Shell getShell() throws IOException {
         if (shell == null) {
             shell = password.isEmpty()
                     ?

--- a/src/main/java/io/webfolder/cdp/RemoteLauncherBuilder.java
+++ b/src/main/java/io/webfolder/cdp/RemoteLauncherBuilder.java
@@ -11,7 +11,7 @@ public class RemoteLauncherBuilder {
 
     public RemoteLauncherBuilder withHost(String host) {
         if (host == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException();
         this.host = host;
         return this;
     }
@@ -28,14 +28,14 @@ public class RemoteLauncherBuilder {
 
     public RemoteLauncherBuilder withUser(String user) {
         if (user == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException();
         this.user = user;
         return this;
     }
 
     public RemoteLauncherBuilder withPassword(String password) {
         if (password == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException();
         this.password = password;
         return this;
     }
@@ -43,14 +43,14 @@ public class RemoteLauncherBuilder {
 
     public RemoteLauncherBuilder withPrivateKey(String privateKey) {
         if (privateKey == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException();
         this.privateKey = privateKey;
         return this;
     }
 
     public RemoteLauncherBuilder withChromeExecutable(String chromeExecutable) {
         if (chromeExecutable == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException();
         this.chromeExecutable = chromeExecutable;
         return this;
     }

--- a/src/main/java/io/webfolder/cdp/RemoteLauncherBuilder.java
+++ b/src/main/java/io/webfolder/cdp/RemoteLauncherBuilder.java
@@ -1,0 +1,62 @@
+package io.webfolder.cdp;
+
+public class RemoteLauncherBuilder {
+    private String host = "127.0.0.1";
+    private int sshPort = 22;
+    private int chromePort = 9222;
+    private String user = "root";
+    private String password = "";
+    private String privateKey = "";
+    private String chromeExecutable = "google-chrome";
+
+    public RemoteLauncherBuilder withHost(String host) {
+        if (host == null)
+            throw new NullPointerException();
+        this.host = host;
+        return this;
+    }
+
+    public RemoteLauncherBuilder withSshPort(int sshPort) {
+        this.sshPort = sshPort;
+        return this;
+    }
+
+    public RemoteLauncherBuilder withChromePort(int chromePort) {
+        this.chromePort = chromePort;
+        return this;
+    }
+
+    public RemoteLauncherBuilder withUser(String user) {
+        if (user == null)
+            throw new NullPointerException();
+        this.user = user;
+        return this;
+    }
+
+    public RemoteLauncherBuilder withPassword(String password) {
+        if (password == null)
+            throw new NullPointerException();
+        this.password = password;
+        return this;
+    }
+
+
+    public RemoteLauncherBuilder withPrivateKey(String privateKey) {
+        if (privateKey == null)
+            throw new NullPointerException();
+        this.privateKey = privateKey;
+        return this;
+    }
+
+    public RemoteLauncherBuilder withChromeExecutable(String chromeExecutable) {
+        if (chromeExecutable == null)
+            throw new NullPointerException();
+        this.chromeExecutable = chromeExecutable;
+        return this;
+    }
+
+    public RemoteLauncher create() {
+        return new RemoteLauncher(host, sshPort,
+                chromePort, user, password, privateKey, chromeExecutable);
+    }
+}

--- a/src/test/java/io/webfolder/cdp/sample/RemoteLaunching.java
+++ b/src/test/java/io/webfolder/cdp/sample/RemoteLaunching.java
@@ -1,0 +1,33 @@
+package io.webfolder.cdp.sample;
+
+import io.webfolder.cdp.RemoteLauncher;
+import io.webfolder.cdp.RemoteLauncherBuilder;
+import io.webfolder.cdp.session.SessionFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Arrays.asList;
+
+public class RemoteLaunching {
+    public static void main(String... args) throws IOException {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+                new FileInputStream(new File("path/to/your/private/key")),
+                StandardCharsets.UTF_8))) {
+            String s;
+            while ((s = br.readLine()) != null)
+                pw.println(s);
+        }
+
+        RemoteLauncher l = new RemoteLauncherBuilder()
+                .withHost("1.2.3.4").withChromePort(12345)
+                .withUser("chromeuser")
+                .withPrivateKey(sw.toString())
+                .create();
+        SessionFactory sf = l.launch(asList("--headless", "--disable-gpu"));
+
+        l.kill();
+    }
+}


### PR DESCRIPTION
RemoteLauncher adds ability to launch and kill Chrome on remote machine
via SSH.

1. Common functionality and some of methods moved to AbstractLauncher. 
2. Method launch(String chromeExecutablePath, List<String> arguments) moved to AbastractLauncher and turned into 'template method' pattern, with auxiliary 'protected internalLaunch' method.
3. jcabi-ssh library is used as a convenience wrapper for JSch.
4. As too many parameters needed to launch RemoteLauncher, and many of them have default values, 'builder' pattern is used to construct RemoteLauncher (RemoteLauncherBuilder class).
5. RemoteLaunching.java added to examples directory.
6. We run Chrome as a background process and obtain its PID using echo $!. When we need to kill Chrome, we just issue kill <PID> over SSH.