### PR TITLE
Make ProcessManager's setProcess public in order to allow full custom implementation of ProcessManager

### DIFF
--- a/src/main/java/io/webfolder/cdp/AdaptiveProcessManager.java
+++ b/src/main/java/io/webfolder/cdp/AdaptiveProcessManager.java
@@ -48,7 +48,7 @@ public class AdaptiveProcessManager extends ProcessManager {
     }
 
     @Override
-    void setProcess(CdpProcess process) {
+    public void setProcess(CdpProcess process) {
         processManager.setProcess(process);
     }
 

--- a/src/main/java/io/webfolder/cdp/DefaultProcessManager.java
+++ b/src/main/java/io/webfolder/cdp/DefaultProcessManager.java
@@ -32,7 +32,7 @@ public class DefaultProcessManager extends ProcessManager {
     private String command;
 
     @Override
-    void setProcess(CdpProcess process) {
+    public void setProcess(CdpProcess process) {
         ProcessHandle handle = process.getProcess().toHandle();
         Info info = handle.info();
         startTime = info.startInstant().get();

--- a/src/main/java/io/webfolder/cdp/Launcher.java
+++ b/src/main/java/io/webfolder/cdp/Launcher.java
@@ -51,7 +51,7 @@ public class Launcher extends AbstractLauncher {
     private static class NullProcessManager extends ProcessManager {
 
         @Override
-        void setProcess(CdpProcess process) {
+        public void setProcess(CdpProcess process) {
         }
 
         @Override

--- a/src/main/java/io/webfolder/cdp/LinuxProcessManager.java
+++ b/src/main/java/io/webfolder/cdp/LinuxProcessManager.java
@@ -34,7 +34,7 @@ public class LinuxProcessManager extends ProcessManager {
     private String cdp4jId;
 
     @Override
-    void setProcess(CdpProcess process) {
+    public void setProcess(CdpProcess process) {
         try {
             Field pidField = process.getProcess().getClass().getDeclaredField("pid");
             pidField.setAccessible(true);

--- a/src/main/java/io/webfolder/cdp/ProcessManager.java
+++ b/src/main/java/io/webfolder/cdp/ProcessManager.java
@@ -19,7 +19,7 @@ package io.webfolder.cdp;
 
 public abstract class ProcessManager {
 
-    abstract void setProcess(CdpProcess process);
+    public abstract void setProcess(CdpProcess process);
 
     public abstract boolean kill();
 }

--- a/src/main/java/io/webfolder/cdp/WindowsProcessManager.java
+++ b/src/main/java/io/webfolder/cdp/WindowsProcessManager.java
@@ -26,7 +26,7 @@ public class WindowsProcessManager extends ProcessManager {
     private String cdp4jId;
 
     @Override
-    void setProcess(CdpProcess process) {
+    public void setProcess(CdpProcess process) {
         WinProcess winProcess = new WinProcess(process.getProcess());
         pid = winProcess.getPid();
         cdp4jId = winProcess.getEnvironmentVariables().get("CDP4J_ID");


### PR DESCRIPTION
I was trying to make a custom implementation of ProcessManager but since the setProcess method is not public, I was not able to do so.