### PR TITLE
Add Session Factory connection timeout configuration to WS context await timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.classpath
 /.project
 /src/test/java/io/webfolder/cdp/sample/Generator.java
+/.idea
+/*.iml

--- a/src/main/java/io/webfolder/cdp/session/Session.java
+++ b/src/main/java/io/webfolder/cdp/session/Session.java
@@ -138,6 +138,10 @@ public class Session implements AutoCloseable,
         return sessionId;
     }
 
+    public int getConnectionTimeout(){
+        return sesessionFactory.getConnectionTimeout();
+    }
+
     /**
      * Close the this browser window
      */

--- a/src/main/java/io/webfolder/cdp/session/SessionFactory.java
+++ b/src/main/java/io/webfolder/cdp/session/SessionFactory.java
@@ -175,6 +175,8 @@ public class SessionFactory implements AutoCloseable {
         return host;
     }
 
+    public int getConnectionTimeout(){ return connectionTimeout; }
+
     public Session create() {
         return create(null);
     }

--- a/src/main/java/io/webfolder/cdp/session/SessionInvocationHandler.java
+++ b/src/main/java/io/webfolder/cdp/session/SessionInvocationHandler.java
@@ -106,7 +106,7 @@ class SessionInvocationHandler implements InvocationHandler {
             context = new WSContext();
             contextList.put(id, context);
             webSocket.sendText(json);
-            context.await();
+            context.await(session.getConnectionTimeout());
         } else {
             throw new CdpException("WebSocket connection is not alive");
         }

--- a/src/main/java/io/webfolder/cdp/session/WSContext.java
+++ b/src/main/java/io/webfolder/cdp/session/WSContext.java
@@ -17,7 +17,7 @@
  */
 package io.webfolder.cdp.session;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -34,11 +34,9 @@ class WSContext {
 
     private CommandException error;
 
-    private static final int WS_TIMEOUT = 10; // 10 seconds
-
-    void await() {
+   void await(int timeout) {
         try {
-            latch.await(WS_TIMEOUT, SECONDS);
+            latch.await(timeout, MILLISECONDS);
         } catch (InterruptedException e) {
             throw new CdpException(e);
         }


### PR DESCRIPTION
This PR adds the Session Factory connection timeout configuration to the WSContext await timeout.

This will allow the client to configure the WSContext await timeout inline with the WS connection timeout.

This is needed as I am experiencing WSContext timeouts when executing the printToPDF Page command when printing large files in a concurrent environment. This is due to the printToPDF command taking longer than 10 seconds.