### PR TITLE
Take stable Chromium instead of latest & use Apache Commons Compression to support symlinks in zip files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,11 @@
    <version>1.9.5</version>
    <scope>test</scope>
   </dependency>
+  <dependency>
+   <groupId>org.apache.commons</groupId>
+   <artifactId>commons-compress</artifactId>
+   <version>1.17</version>
+  </dependency>
  </dependencies>
  <properties>
   <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>

--- a/src/main/java/io/webfolder/cdp/ChromiumDownloader.java
+++ b/src/main/java/io/webfolder/cdp/ChromiumDownloader.java
@@ -1,17 +1,17 @@
 /**
  * cdp4j - Chrome DevTools Protocol for Java
  * Copyright © 2017, 2018 WebFolder OÜ (support@webfolder.io)
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -50,17 +50,17 @@ import static java.util.Locale.ENGLISH;
 
 public class ChromiumDownloader implements Downloader {
 
-    private static final String OS = getProperty("os.name").toLowerCase(ENGLISH);
+    private static final String OS            = getProperty("os.name").toLowerCase(ENGLISH);
 
-    private static final boolean WINDOWS = ";".equals(pathSeparator);
+    private static final boolean WINDOWS      = ";".equals(pathSeparator);
 
-    private static final boolean MAC = OS.contains("mac");
+    private static final boolean MAC          = OS.contains("mac");
 
-    private static final boolean LINUX = OS.contains("linux");
+    private static final boolean LINUX        = OS.contains("linux");
 
     private static final String DOWNLOAD_HOST = "https://storage.googleapis.com/chromium-browser-snapshots";
 
-    private static final String VERSION_URL = "https://raw.githubusercontent.com/GoogleChrome/puppeteer/master/package.json";
+    private static final String VERSION_URL   = "https://raw.githubusercontent.com/GoogleChrome/puppeteer/master/package.json";
 
     private static final int TIMEOUT = 10 * 1000; // 10 seconds
 
@@ -107,17 +107,17 @@ public class ChromiumDownloader implements Downloader {
 
     public static Path getChromiumPath(ChromiumVersion version) {
         Path destinationRoot = get(getProperty("user.home"))
-                .resolve(".cdp4j")
-                .resolve("chromium-" + valueOf(version.getRevision()));
+                                .resolve(".cdp4j")
+                                .resolve("chromium-" + valueOf(version.getRevision()));
         return destinationRoot;
     }
 
     public static Path getExecutable(ChromiumVersion version) {
         Path destinationRoot = getChromiumPath(version);
         Path executable = destinationRoot.resolve("chrome.exe");
-        if (LINUX) {
+        if ( LINUX ) {
             executable = destinationRoot.resolve("chrome");
-        } else if (MAC) {
+        } else if ( MAC ) {
             executable = destinationRoot.resolve("Chromium.app/Contents/MacOS/Chromium");
         }
         return executable;
@@ -128,11 +128,11 @@ public class ChromiumDownloader implements Downloader {
         final Path executable = getExecutable(version);
 
         String url;
-        if (WINDOWS) {
+        if ( WINDOWS ) {
             url = format("%s/Win_x64/%d/chrome-win32.zip", DOWNLOAD_HOST, version.getRevision());
-        } else if (LINUX) {
+        } else if ( LINUX ) {
             url = format("%s/Linux_x64/%d/chrome-linux.zip", DOWNLOAD_HOST, version.getRevision());
-        } else if (MAC) {
+        } else if ( MAC ) {
             url = format("%s/Mac/%d/chrome-mac.zip", DOWNLOAD_HOST, version.getRevision());
         } else {
             throw new CdpException("Unsupported OS found - " + OS);
@@ -144,19 +144,19 @@ public class ChromiumDownloader implements Downloader {
             conn.setRequestMethod("HEAD");
             conn.setConnectTimeout(TIMEOUT);
             conn.setReadTimeout(TIMEOUT);
-            if (conn.getResponseCode() != 200) {
+            if ( conn.getResponseCode() != 200 ) {
                 throw new CdpException(conn.getResponseCode() + " - " + conn.getResponseMessage());
             }
             long contentLength = conn.getHeaderFieldLong("x-goog-stored-content-length", 0);
             String fileName = url.substring(url.lastIndexOf("/") + 1, url.lastIndexOf(".")) + "-r" + version.getRevision() + ".zip";
             Path archive = get(getProperty("java.io.tmpdir")).resolve(fileName);
-            if (exists(archive) && contentLength != size(archive)) {
+            if ( exists(archive) && contentLength != size(archive) ) {
                 delete(archive);
             }
-            if (!exists(archive)) {
+            if ( ! exists(archive) ) {
                 logger.info("Downloading Chromium [revision=" + version.getRevision() + "] 0%");
                 u = new URL(url);
-                if (conn.getResponseCode() != 200) {
+                if ( conn.getResponseCode() != 200 ) {
                     throw new CdpException(conn.getResponseCode() + " - " + conn.getResponseMessage());
                 }
                 conn = (HttpURLConnection) u.openConnection();
@@ -193,7 +193,7 @@ public class ChromiumDownloader implements Downloader {
                     thread.start();
                     copy(conn.getInputStream(), archive);
                 } finally {
-                    if (thread != null) {
+                    if ( thread != null ) {
                         progress.run();
                         halt.set(true);
                     }
@@ -212,15 +212,15 @@ public class ChromiumDownloader implements Downloader {
 
     public static List<ChromiumVersion> getInstalledVersions() {
         Path chromiumRootPath = get(getProperty("user.home")).resolve(".cdp4j");
-        if (!Files.exists(chromiumRootPath)) {
+        if ( ! Files.exists(chromiumRootPath) ) {
             return Collections.emptyList();
         }
         try {
             List<ChromiumVersion> list = list(chromiumRootPath)
-                    .filter(p -> isDirectory(p))
-                    .filter(p -> p.getFileName().toString().startsWith("chromium-"))
-                    .map(p -> new ChromiumVersion(parseInt(p.getFileName().toString().split("-")[1])))
-                    .collect(Collectors.toList());
+                                            .filter(p -> isDirectory(p))
+                                            .filter(p -> p.getFileName().toString().startsWith("chromium-"))
+                                            .map(p -> new ChromiumVersion(parseInt(p.getFileName().toString().split("-")[1])))
+                                        .collect(Collectors.toList());
             list.sort((o1, o2) -> compare(o2.getRevision(), o1.getRevision()));
             return list;
         } catch (IOException e) {
@@ -230,6 +230,6 @@ public class ChromiumDownloader implements Downloader {
 
     public static ChromiumVersion getLatestInstalledVersion() {
         List<ChromiumVersion> versions = getInstalledVersions();
-        return !versions.isEmpty() ? versions.get(0) : null;
+        return ! versions.isEmpty() ? versions.get(0) : null;
     }
 }

--- a/src/main/java/io/webfolder/cdp/ZipUtils.java
+++ b/src/main/java/io/webfolder/cdp/ZipUtils.java
@@ -1,0 +1,97 @@
+package io.webfolder.cdp;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.utils.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
+
+import static java.nio.file.attribute.PosixFilePermission.*;
+
+public class ZipUtils {
+
+    private static final PosixFilePermission[] decodeMap = {
+            OTHERS_EXECUTE,
+            OTHERS_WRITE,
+            OTHERS_READ,
+            GROUP_EXECUTE,
+            GROUP_WRITE,
+            GROUP_READ,
+            OWNER_EXECUTE,
+            OWNER_WRITE,
+            OWNER_READ
+    };
+
+    public static void unpack(File archiveFile, File destFolder) throws IOException {
+        ZipFile zf = new ZipFile(archiveFile);
+
+        Map<File, String> symLinks = new HashMap<>();
+
+        Iterator<ZipArchiveEntry> iterator = zf.getEntries().asIterator();
+
+        //Top directory name we are going to ignore
+        String parentDirectory = iterator.next().getName();
+
+        //Iterate files & folders
+        while (iterator.hasNext()) {
+            ZipArchiveEntry entry = iterator.next();
+            String name = entry.getName().substring(parentDirectory.length());
+            File outputFile = new File(destFolder, name);
+
+            if (entry.isUnixSymlink()) {
+                symLinks.put(outputFile, zf.getUnixSymlink(entry));
+            } else if (!entry.isDirectory()) {
+                if (!outputFile.getParentFile().isDirectory()) {
+                    outputFile.getParentFile().mkdirs();
+                }
+
+                IOUtils.copy(zf.getInputStream(entry), new FileOutputStream(outputFile));
+            }
+
+            // Set permission
+            if (!entry.isUnixSymlink() && outputFile.exists())
+                try {
+                    Files.setPosixFilePermissions(
+                            outputFile.toPath(),
+                            modeToPosixPermissions(entry.getUnixMode())
+                    );
+                } catch (Exception ignored) {
+                }
+        }
+
+        for (Map.Entry<File, String> entry : symLinks.entrySet())
+            try {
+                Path source = Paths.get(entry.getKey().getAbsolutePath());
+                Path target = source.getParent().resolve(entry.getValue());
+                if (!source.toFile().exists())
+                    Files.createSymbolicLink(
+                            source,
+                            target
+                    );
+            } catch (Exception ignored) {
+            }
+
+    }
+
+    private static Set<PosixFilePermission> modeToPosixPermissions(final int mode) {
+        int mask = 1;
+
+        Set<PosixFilePermission> perms = EnumSet.noneOf(PosixFilePermission.class);
+        for (PosixFilePermission flag : decodeMap) {
+            if ((mask & mode) != 0) {
+                perms.add(flag);
+            }
+            mask = mask << 1;
+        }
+
+        return perms;
+    }
+
+}


### PR DESCRIPTION
MacOS version (and probably linux as well) of unzipping didn't work because of the symlinks used inside chromium zip file. Shifted to Apache Commons Compression in order to fix that.

Changed latest Chromium version to latest stable supported by puppeteer (as a trusted source of a properly tested Chromium for CDP).