### PR TITLE
Fix link to jar artifact in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This library is suitable for use in production systems.
 
 Download
 --------
-[cdp4j-4.1.0.jar](https://github.com/webfolderio/cdp4j/releases/download/4.1.0/cdp4j-4.1.0-sources.jar)
+[cdp4j-4.1.0.jar](https://github.com/webfolderio/cdp4j/releases/download/4.1.0/cdp4j-4.1.0.jar)
 
 [cdp4j-4.1.0-sources.jar](https://github.com/webfolderio/cdp4j/releases/download/4.1.0/cdp4j-4.1.0-sources.jar)
 


### PR DESCRIPTION
Link is pointing to the wrong artifact location in the README