### PR TITLE
Wait for termination in DefaultProcessManager.kill()

### DIFF
--- a/src/main/java11/io/webfolder/cdp/DefaultProcessManager.java
+++ b/src/main/java11/io/webfolder/cdp/DefaultProcessManager.java
@@ -64,7 +64,11 @@ public class DefaultProcessManager extends ProcessManager {
                         }
                     });
                 }
-                return handle.destroyForcibly();
+                boolean success = handle.destroyForcibly();
+                if (success) {
+                    handle.onExit().join();
+                }
+                return success;
             }
         }
         return false;


### PR DESCRIPTION
The `destroyForcibly` method of `ProcessHandle` does not guarantee that process will be terminated upon return, as mentioned in its javadoc:
> Note: The process may not terminate immediately. For example, isAlive() may return true for a brief period after destroyForcibly() is called.

Indeed, I had tests failing with the following exception before this fix:
```
CdpException: --user-data-dir [/tmp/remote-profile] is used by another process.
```

The fix in this PR ensures that process is not alive before return from `kill()`.